### PR TITLE
Check if lastrow[3] is defined 

### DIFF
--- a/data/js/PinPatrol.js
+++ b/data/js/PinPatrol.js
@@ -158,7 +158,7 @@ function writeTable(list){
                     //include subdomains
                     var subDomains = lastrow[2] == 1 ? "includeSubdomains" : " - ";
 
-                    if(lastrow[3] != 0 && lastrow[3] != 2){
+                    if(typeof lastrow[3] !== 'undefined' && lastrow[3] != 0 && lastrow[3] != 2){
                         var pins = lastrow[3].split("=");
                         var temp = "";
                         for(var k = 0; k < pins.length; k++){


### PR DESCRIPTION
Check if lastrow[3] is defined for HPKP before trying to read it, otherwise SiteSecurityServiceState.txt would not load if HSTS entries were present.

Error fixed by this PR:
![typeerror](https://user-images.githubusercontent.com/29507827/35045934-738a3656-fb63-11e7-856e-4c6da1da1b22.png)



